### PR TITLE
Add trusted proxy handling for Roblox allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,35 @@
 - No banning
 - Allow access to all API
 - Built on top of Fastify (which is blazingly fast)
+
+## Configuration
+
+Update `config.json` before starting the proxy:
+
+| Field | Description |
+| --- | --- |
+| `onlyRobloxServer` | When `true`, only Roblox IP ranges can access the proxy. |
+| `placeIds` | Optional Roblox place IDs that must be provided via the `roblox-id` header. Leave empty to accept any place. |
+| `apiKeys` | Optional list of API keys that must be sent in the `proxy-authorization` header. |
+| `trustedReverseProxies` | IP addresses of reverse proxies/load balancers that you control. Requests coming from these peers may forward the Roblox source IP via the `X-Forwarded-For` header and will be checked against the allowlist. Spoofed headers coming directly from the internet are ignored, keeping the Roblox-only restriction intact. |
+
+Example:
+
+```json
+{
+  "onlyRobloxServer": true,
+  "placeIds": ["123456"],
+  "apiKeys": ["example-key"],
+  "trustedReverseProxies": ["10.0.0.1"]
+}
+```
+
+With the above configuration a Roblox server connecting through the reverse proxy at `10.0.0.1` may forward its original IP in `X-Forwarded-For`. The allowlist now sees the actual Roblox IP, while a malicious client that spoofs the header without coming through the trusted proxy will still be rejected.
+
+## Testing
+
+Run the automated tests to verify the header handling logic:
+
+```bash
+pnpm test
+```

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "onlyRobloxServer": false,
   "placeIds": [],
-  "apiKeys": []
+  "apiKeys": [],
+  "trustedReverseProxies": []
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "scripts": {
     "build": "del-cli dist && tsc",
-    "start": "node ."
+    "start": "node .",
+    "test": "node --test -r ts-node/register tests/robloxGuard.test.ts"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@types/node": "^20.5.7",
     "del-cli": "^5.1.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.2.2"
   },
   "packageManager": "pnpm@8.7.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ devDependencies:
   del-cli:
     specifier: ^5.1.0
     version: 5.1.0
+  ts-node:
+    specifier: ^10.9.2
+    version: 10.9.2(@types/node@20.5.7)(typescript@5.2.2)
   typescript:
     specifier: ^5.2.2
     version: 5.2.2
@@ -60,6 +63,13 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
+    dev: true
+
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
   /@fastify/accept-negotiator@1.1.0:
@@ -147,6 +157,22 @@ packages:
       fastify-plugin: 4.5.1
     dev: false
 
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -166,6 +192,22 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
+    dev: true
+
+  /@tsconfig/node10@1.0.12:
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
   /@types/minimist@1.2.2:
@@ -190,6 +232,19 @@ packages:
   /abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
     dev: false
+
+  /acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.15.0
+    dev: true
+
+  /acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
 
   /aggregate-error@4.0.1:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
@@ -229,6 +284,10 @@ packages:
   /archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
     dev: false
+
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
 
   /arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -344,6 +403,10 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: false
 
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -395,6 +458,11 @@ packages:
       p-map: 5.5.0
       rimraf: 3.0.2
       slash: 4.0.0
+    dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
     dev: true
 
   /dir-glob@3.0.1:
@@ -770,6 +838,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
 
   /map-obj@1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
@@ -1247,6 +1319,37 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /ts-node@10.9.2(@types/node@20.5.7)(typescript@5.2.2):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.5.7
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.2.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /type-fest@1.4.0:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
@@ -1274,6 +1377,10 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: false
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -1309,6 +1416,11 @@ packages:
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
     dev: true
 
   /yocto-queue@0.1.0:

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,175 @@
+import fastify, {
+  type FastifyInstance,
+  type FastifyReply,
+  type FastifyRequest,
+  type HookHandlerDoneFunction,
+} from "fastify";
+import fastifyUnderpressure from "@fastify/under-pressure";
+import fastifyRatelimit from "@fastify/rate-limit";
+import fastifyCompress from "@fastify/compress";
+import fastifyProxy from "@fastify/http-proxy";
+import fastifyHelmet from "@fastify/helmet";
+
+import { robloxRanges } from "./robloxRanges";
+
+const PROJECT_PATH = "https://github.com/xhayper/DiscordProxy";
+const LOCAL_IPS = new Set(["localhost", "::1", "127.0.0.1", "::ffff:127.0.0.1"]);
+
+export type AppConfig = {
+  onlyRobloxServer: boolean;
+  placeIds: string[];
+  apiKeys: string[];
+  trustedReverseProxies?: string[];
+};
+
+export type PackageInfo = {
+  version: string;
+};
+
+const normalizeAddress = (address: string | undefined) => {
+  if (!address) return "";
+  return address.startsWith("::ffff:") ? address.slice(7) : address;
+};
+
+export const buildTrustedProxySet = (entries: string[] | undefined) => {
+  const set = new Set<string>();
+
+  for (const value of entries ?? []) {
+    set.add(value);
+    const normalized = normalizeAddress(value);
+    set.add(normalized);
+  }
+
+  return set;
+};
+
+const isLocalIp = (ip: string) => {
+  if (!ip) return false;
+  if (LOCAL_IPS.has(ip)) return true;
+  const normalized = normalizeAddress(ip);
+  return LOCAL_IPS.has(normalized);
+};
+
+const buildForbiddenResponse = (reply: FastifyReply) =>
+  reply.code(403).send({ error: "You are not allowed to use this proxy." });
+
+export const resolveClientIp = (
+  request: FastifyRequest,
+  trustedProxies: Set<string>
+) => {
+  const remoteAddress = normalizeAddress(
+    request.socket.remoteAddress ?? request.ip
+  );
+
+  if (!trustedProxies.has(remoteAddress)) {
+    return normalizeAddress(request.ip);
+  }
+
+  const forwardedHeader = request.headers["x-forwarded-for"];
+  const forwarded = Array.isArray(forwardedHeader)
+    ? forwardedHeader[0]
+    : forwardedHeader;
+
+  if (!forwarded) return remoteAddress;
+
+  const [firstHop] = forwarded.split(",");
+
+  return normalizeAddress(firstHop?.trim());
+};
+
+export const createProxyPreHandler = (
+  config: AppConfig,
+  apiKeys: Set<string>,
+  trustedProxies: Set<string>
+) =>
+  (
+    request: FastifyRequest,
+    reply: FastifyReply,
+    done: HookHandlerDoneFunction
+  ) => {
+    if (config.apiKeys.length > 0) {
+      const headers = request.headers;
+      const apiKeyHeader = headers["proxy-authorization"];
+      const apiKey = Array.isArray(apiKeyHeader)
+        ? apiKeyHeader[0]
+        : apiKeyHeader;
+
+      if (!apiKey || !apiKeys.has(apiKey)) {
+        buildForbiddenResponse(reply);
+        return done();
+      }
+
+      delete headers["proxy-authorization"];
+    }
+
+    if (!config.onlyRobloxServer) return done();
+
+    const ip = resolveClientIp(request, trustedProxies);
+
+    if (isLocalIp(ip)) return done();
+
+    if (config.placeIds.length > 0) {
+      const headers = request.headers;
+      const placeIdHeader = headers["roblox-id"];
+      const placeId = Array.isArray(placeIdHeader)
+        ? placeIdHeader[0]
+        : placeIdHeader;
+
+      if (!placeId || !config.placeIds.includes(placeId)) {
+        buildForbiddenResponse(reply);
+        return done();
+      }
+    }
+
+    if (!robloxRanges.check(ip)) {
+      buildForbiddenResponse(reply);
+      return done();
+    }
+
+    return done();
+  };
+
+export const buildApp = (config: AppConfig, pkg: PackageInfo): FastifyInstance => {
+  const apiKeys = new Set(config.apiKeys);
+  const trustedProxies = buildTrustedProxySet(config.trustedReverseProxies);
+  const app = fastify();
+
+  app.register(fastifyCompress);
+  app.register(fastifyHelmet, { global: true });
+
+  app.register(fastifyUnderpressure, {
+    maxEventLoopDelay: 1000,
+    maxHeapUsedBytes: 100000000,
+    maxRssBytes: 100000000,
+    maxEventLoopUtilization: 0.98,
+    retryAfter: 50,
+    message: "Under pressure!",
+  });
+
+  app.register(fastifyRatelimit, {
+    max: 100,
+    timeWindow: "1 minute",
+  });
+
+  app.register(fastifyProxy, {
+    upstream: "https://discord.com",
+    prefix: "/api",
+    rewritePrefix: "/api",
+    preHandler: createProxyPreHandler(config, apiKeys, trustedProxies),
+    replyOptions: {
+      rewriteRequestHeaders: (_, headers) => {
+        headers["user-agent"] = `DiscordProxy/${pkg.version} (${PROJECT_PATH})`;
+        delete headers["roblox-id"];
+        return headers;
+      },
+    },
+  });
+
+  app.get("/", async (_, reply) => {
+    reply
+      .code(404)
+      .send({ error: "You are not fetching a correct endpoint!" });
+  });
+
+  return app;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,117 +1,26 @@
 import "dotenv/config";
 
-///////////////////////////////////////////////////////////////////////////
-
-import fastifyUnderpressure from "@fastify/under-pressure";
-import fastifyRatelimit from "@fastify/rate-limit";
-import fastifyCompress from "@fastify/compress";
-import fastifyProxy from "@fastify/http-proxy";
-import fastifyHelmet from "@fastify/helmet";
-
-import { robloxRanges } from "./robloxRanges";
 import fs from "node:fs/promises";
-import fastify from "fastify";
 import path from "node:path";
 
-const LOCAL_IP = ["localhost", "::1", "127.0.0.1", "::ffff:"];
-const PROJECT_PATH = "https://github.com/xhayper/DiscordProxy";
+import { buildApp, type AppConfig, type PackageInfo } from "./app";
 
 (async () => {
   const config = JSON.parse(
     await fs.readFile(path.join(__dirname, "../", "config.json"), "utf-8")
-  ) as {
-    onlyRobloxServer: boolean;
-    placeIds: string[];
-    apiKeys: string[];
-  };
+  ) as AppConfig;
   const pkg = JSON.parse(
     await fs.readFile(path.join(__dirname, "../", "package.json"), "utf-8")
-  ) as {
-    version: string;
-  };
+  ) as PackageInfo;
+
+  config.apiKeys ??= [];
+  config.placeIds ??= [];
+  config.trustedReverseProxies ??= [];
 
   if (config.placeIds.length > 0)
     console.log("Place ID list is not empty! Tracking enabled.");
 
-  const apiKeys = new Set(config.apiKeys);
-
-  const app = fastify();
-
-  app.register(fastifyCompress);
-  app.register(fastifyHelmet, { global: true });
-
-  app.register(fastifyUnderpressure, {
-    maxEventLoopDelay: 1000,
-    maxHeapUsedBytes: 100000000,
-    maxRssBytes: 100000000,
-    maxEventLoopUtilization: 0.98,
-    retryAfter: 50,
-    message: "Under pressure!",
-  });
-
-  app.register(fastifyRatelimit, {
-    max: 100,
-    timeWindow: "1 minute",
-  });
-
-  app.register(fastifyProxy, {
-    upstream: "https://discord.com",
-    prefix: "/api",
-    rewritePrefix: "/api",
-    preHandler: (request, reply, done) => {
-      if (config.apiKeys.length > 0) {
-        const headers = request.headers;
-        const apiKey = headers["proxy-authorization"];
-
-        if (!apiKey || !apiKeys.has(apiKey as string)) {
-          reply
-            .code(403)
-            .send({ error: "You are not allowed to use this proxy." });
-          return done();
-        }
-
-        delete headers["proxy-authorization"];
-      }
-
-      if (!config.onlyRobloxServer) return done();
-
-      const ip = request.ip;
-
-      if (LOCAL_IP.includes(ip)) return done();
-
-      if (config.placeIds.length > 0) {
-        const headers = request.headers;
-        const placeId = headers["roblox-id"];
-
-        if (!placeId || !config.placeIds.includes(placeId as string)) {
-          reply
-            .code(403)
-            .send({ error: "You are not allowed to use this proxy." });
-          return done();
-        }
-      }
-
-      if (!robloxRanges.check(ip)) {
-        reply
-          .code(403)
-          .send({ error: "You are not allowed to use this proxy." });
-        return done();
-      }
-
-      return done();
-    },
-    replyOptions: {
-      rewriteRequestHeaders: (_, headers) => {
-        headers["user-agent"] = `DiscordProxy/${pkg.version} (${PROJECT_PATH})`;
-        delete headers["roblox-id"];
-        return headers;
-      },
-    },
-  });
-
-  app.get("/", async (_, reply) => {
-    reply.code(404).send({ error: "You are not fetching a correct endpoint!"});
-  });
+  const app = buildApp(config, pkg);
 
   app
     .listen({ host: "0.0.0.0", port: parseInt(process.env.PORT ?? "3000") })

--- a/tests/robloxGuard.test.ts
+++ b/tests/robloxGuard.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fastify from "fastify";
+
+import {
+  buildTrustedProxySet,
+  createProxyPreHandler,
+  type AppConfig,
+} from "../src/app";
+
+const baseConfig: AppConfig = {
+  onlyRobloxServer: true,
+  placeIds: [],
+  apiKeys: [],
+  trustedReverseProxies: ["10.0.0.1"],
+};
+
+const buildTestServer = (config: AppConfig) => {
+  const trusted = buildTrustedProxySet(config.trustedReverseProxies);
+  const app = fastify({
+  });
+
+  app.route({
+    method: "GET",
+    url: "/api/test",
+    preHandler: createProxyPreHandler(
+      config,
+      new Set(config.apiKeys),
+      trusted
+    ),
+    handler: async () => ({ ok: true }),
+  });
+
+  return app;
+};
+
+test("allows Roblox IPs forwarded by trusted reverse proxies", async (t) => {
+  const app = buildTestServer(baseConfig);
+  t.after(() => app.close());
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/api/test",
+    remoteAddress: "10.0.0.1",
+    headers: {
+      "x-forwarded-for": "128.116.0.10",
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+});
+
+test("blocks spoofed X-Forwarded-For headers from untrusted clients", async (t) => {
+  const app = buildTestServer(baseConfig);
+  t.after(() => app.close());
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/api/test",
+    remoteAddress: "203.0.113.5",
+    headers: {
+      "x-forwarded-for": "128.116.0.10",
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+});


### PR DESCRIPTION
## Summary
- add a reusable Fastify bootstrap that resolves the client IP from trusted reverse proxies before running the Roblox range checks
- document the new `trustedReverseProxies` option and add coverage that proves proxied Roblox IPs are allowed while spoofed headers from untrusted peers are denied

## Testing
- `pnpm test`
- `pnpm build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4da1141483218ed7699556029a96)