### PR TITLE
Honor forwarded client IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@
 - No banning
 - Allow access to all API
 - Built on top of Fastify (which is blazingly fast)
+
+## Forwarded IP handling
+
+DiscordProxy expects upstream load balancers to forward the caller's address in the standard [`X-Forwarded-For`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) header. Fastify is configured with `trustProxy` so the left-most entry in that header becomes `request.ip`, which is what both the Roblox subnet gate and the rate-limit plugin rely on.
+
+If your deployment has multiple reverse proxies in front of DiscordProxy, set the number of trusted hops via the `TRUSTED_PROXY_HOPS` environment variable so Fastify knows how many addresses to trust when parsing `X-Forwarded-For`. Leaving it unset trusts the entire chain (the default).

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,19 @@ const PROJECT_PATH = "https://github.com/xhayper/DiscordProxy";
 
   const apiKeys = new Set(config.apiKeys);
 
-  const app = fastify();
+  const trustProxySetting = (() => {
+    const trustedProxyHops = process.env.TRUSTED_PROXY_HOPS;
+
+    if (!trustedProxyHops) return true;
+
+    const hopCount = Number.parseInt(trustedProxyHops, 10);
+
+    if (Number.isNaN(hopCount) || hopCount < 1) return true;
+
+    return hopCount;
+  })();
+
+  const app = fastify({ trustProxy: trustProxySetting });
 
   app.register(fastifyCompress);
   app.register(fastifyHelmet, { global: true });


### PR DESCRIPTION
## Summary
- configure Fastify to trust the X-Forwarded-For header and allow deployments to set the number of trusted proxy hops via `TRUSTED_PROXY_HOPS`
- document the expected X-Forwarded-For header so operators know how Roblox filtering and rate limiting derive the client address

## Testing
- pnpm build
- curl -i -H 'X-Forwarded-For: 8.8.8.8, 203.0.113.9' http://127.0.0.1:3100/api
- curl -i -H 'X-Forwarded-For: 128.116.0.2, 203.0.113.9' http://127.0.0.1:3100/api (twice)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4dd708b08321b6f7e921715320ea)